### PR TITLE
Support RFC 6570 optional path segments

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -9,7 +9,7 @@ var ArrayModel = function(definition) {
   this.name = "arrayModel";
   this.definition = definition || {};
   this.properties = [];
-  
+
   var requiredFields = definition.enum || [];
   var innerType = definition.items;
   if(innerType) {
@@ -836,7 +836,13 @@ Operation.prototype.urlify = function (args) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         else
           value = this.encodePathParam(value);
-        requestUrl = requestUrl.replace(reg, value);
+        if(reg.exec(requestUrl)) {
+            requestUrl = requestUrl.replace(reg, value);
+        } else {
+            // Try optional path segments {/param} too
+            var optionalReg = new RegExp('\{\\/' + param.name + '\}', 'gi');
+            requestUrl = requestUrl.replace(optionalReg, '/' + value);
+        }
       }
       else if (param.in === 'query' && typeof args[param.name] !== 'undefined') {
         if(querystring === '')
@@ -857,6 +863,8 @@ Operation.prototype.urlify = function (args) {
         formParams[param.name] = args[param.name];
     }
   }
+  // Strip out remaining optional path segments
+  requestUrl = requestUrl.replace(/\{\/[^\/}]+\}/g, '');
   var url = this.scheme + '://' + this.host;
 
   if(this.basePath !== '/')
@@ -1416,7 +1424,7 @@ Property.prototype.toString = function() {
   }
 
 
-  var options = ''; 
+  var options = '';
   var isArray = this.schema.type === 'array';
   var type;
 
@@ -1478,11 +1486,11 @@ Property.prototype.toString = function() {
     }
 
     options += optionHtml('Enum', enumString);
-  }     
+  }
 
   if (options.length > 0)
     str = '<span class="propWrap">' + str + '<table class="optionsWrapper"><tr><th colspan="2">' + this.name + '</th></tr>' + options + '</table></span>';
-  
+
   return str;
 };
 
@@ -1842,11 +1850,11 @@ SwaggerResource.prototype.addOperations = function (resource_path, ops, consumes
           o.summary,
           o.notes,
           type,
-          responseMessages, 
-          this, 
-          consumes, 
-          produces, 
-          o.authorizations, 
+          responseMessages,
+          this,
+          consumes,
+          produces,
+          o.authorizations,
           o.deprecated);
 
       this.operations[op.nickname] = op;
@@ -2328,15 +2336,15 @@ SwaggerOperation.prototype.urlify = function (args) {
     param = params[i];
     if(param.paramType === 'query') {
       if (queryParams !== '')
-        queryParams += '&';    
+        queryParams += '&';
       if (Array.isArray(param)) {
-        var output = '';   
-        for(j = 0; j < param.length; j++) {    
-          if(j > 0)    
-            output += ',';   
-          output += encodeURIComponent(param[j]);    
-        }    
-        queryParams += encodeURIComponent(param.name) + '=' + output;    
+        var output = '';
+        for(j = 0; j < param.length; j++) {
+          if(j > 0)
+            output += ',';
+          output += encodeURIComponent(param[j]);
+        }
+        queryParams += encodeURIComponent(param.name) + '=' + output;
       }
       else {
         if (typeof args[param.name] !== 'undefined') {
@@ -2402,7 +2410,7 @@ SwaggerOperation.prototype.asCurl = function (args) {
   var results = [];
   var i;
 
-  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);    
+  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);
   for(i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
     if(param.paramType && param.paramType === 'header' && args[param.name]) {

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -9,7 +9,7 @@ var ArrayModel = function(definition) {
   this.name = "arrayModel";
   this.definition = definition || {};
   this.properties = [];
-  
+
   var requiredFields = definition.enum || [];
   var innerType = definition.items;
   if(innerType) {
@@ -836,7 +836,13 @@ Operation.prototype.urlify = function (args) {
           value = this.encodePathCollection(param.collectionFormat, param.name, value);
         else
           value = this.encodePathParam(value);
-        requestUrl = requestUrl.replace(reg, value);
+        if(reg.exec(requestUrl)) {
+            requestUrl = requestUrl.replace(reg, value);
+        } else {
+            // Try optional path segments {/param} too
+            var optionalReg = new RegExp('\{\\/' + param.name + '\}', 'gi');
+            requestUrl = requestUrl.replace(optionalReg, '/' + value);
+        }
       }
       else if (param.in === 'query' && typeof args[param.name] !== 'undefined') {
         if(querystring === '')
@@ -857,6 +863,8 @@ Operation.prototype.urlify = function (args) {
         formParams[param.name] = args[param.name];
     }
   }
+  // Strip out remaining optional path segments
+  requestUrl = requestUrl.replace(/\{\/[^\/}]+\}/g, '');
   var url = this.scheme + '://' + this.host;
 
   if(this.basePath !== '/')
@@ -1416,7 +1424,7 @@ Property.prototype.toString = function() {
   }
 
 
-  var options = ''; 
+  var options = '';
   var isArray = this.schema.type === 'array';
   var type;
 
@@ -1478,11 +1486,11 @@ Property.prototype.toString = function() {
     }
 
     options += optionHtml('Enum', enumString);
-  }     
+  }
 
   if (options.length > 0)
     str = '<span class="propWrap">' + str + '<table class="optionsWrapper"><tr><th colspan="2">' + this.name + '</th></tr>' + options + '</table></span>';
-  
+
   return str;
 };
 
@@ -1842,11 +1850,11 @@ SwaggerResource.prototype.addOperations = function (resource_path, ops, consumes
           o.summary,
           o.notes,
           type,
-          responseMessages, 
-          this, 
-          consumes, 
-          produces, 
-          o.authorizations, 
+          responseMessages,
+          this,
+          consumes,
+          produces,
+          o.authorizations,
           o.deprecated);
 
       this.operations[op.nickname] = op;
@@ -2328,15 +2336,15 @@ SwaggerOperation.prototype.urlify = function (args) {
     param = params[i];
     if(param.paramType === 'query') {
       if (queryParams !== '')
-        queryParams += '&';    
+        queryParams += '&';
       if (Array.isArray(param)) {
-        var output = '';   
-        for(j = 0; j < param.length; j++) {    
-          if(j > 0)    
-            output += ',';   
-          output += encodeURIComponent(param[j]);    
-        }    
-        queryParams += encodeURIComponent(param.name) + '=' + output;    
+        var output = '';
+        for(j = 0; j < param.length; j++) {
+          if(j > 0)
+            output += ',';
+          output += encodeURIComponent(param[j]);
+        }
+        queryParams += encodeURIComponent(param.name) + '=' + output;
       }
       else {
         if (typeof args[param.name] !== 'undefined') {
@@ -2402,7 +2410,7 @@ SwaggerOperation.prototype.asCurl = function (args) {
   var results = [];
   var i;
 
-  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);    
+  var headers = SwaggerRequest.prototype.setHeaders(args, {}, this);
   for(i = 0; i < this.parameters.length; i++) {
     var param = this.parameters[i];
     if(param.paramType && param.paramType === 'header' && args[param.name]) {


### PR DESCRIPTION
This adds support for the substitution of RFC 6570 optional path segments in
swagger-client. Example:

 /some/path{/optional}{/path}

This patch is rather simple and limited. For example, it does not properly
handle order constraints. A better solution would be to use one of the
existing RFC 6570 libraries. One candidate for this would be
https://github.com/bramstein/url-template.