### PR TITLE
Add a x-textarea hint for post parameters

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -30967,7 +30967,7 @@ Emitter.prototype.hasListeners = function(event){
  * TODO: combatible error handling?
  */
 
-module.exports = function(arr, fn, initial){  
+module.exports = function(arr, fn, initial){
   var idx = 0;
   var len = arr.length;
   var curr = arguments.length == 3
@@ -30977,7 +30977,7 @@ module.exports = function(arr, fn, initial){
   while (idx < len) {
     curr = fn.call(null, curr, arr[idx], ++idx, arr);
   }
-  
+
   return curr;
 };
 },{}]},{},[1])(1)
@@ -32041,7 +32041,8 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
 
     this.model.type = type;
     this.model.paramType = this.model.in || this.model.paramType;
-    this.model.isBody = this.model.paramType === 'body' || this.model.in === 'body';
+    this.model.isBody = this.model.paramType === 'body' || this.model.in === 'body'
+        || this.model['x-textarea'];
     this.model.isFile = type && type.toLowerCase() === 'file';
 
     // Allow for default === false

--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -28,7 +28,9 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
 
     this.model.type = type;
     this.model.paramType = this.model.in || this.model.paramType;
-    this.model.isBody = this.model.paramType === 'body' || this.model.in === 'body';
+    this.model.isBody = this.model.paramType === 'body' || this.model.in === 'body'
+        // hack..
+        || this.model['x-textarea'];
     this.model.isFile = type && type.toLowerCase() === 'file';
 
     // Allow for default === false


### PR DESCRIPTION
Swagger-ui by default supports multi-line input for body parameters. We have
several use cases where other parameters would benefit from multi-line input
as well (such as wikitext to HTML conversions), so this patch adds support for
switching to multi-line textareas by setting a `x-textarea` flag in the
parameter spec.

While this might not be the cleanest way to do it, it works for now. We should
work with upstream to figure out a solution that can be integrated into
swagger-ui proper.

Task: https://phabricator.wikimedia.org/T110712